### PR TITLE
6 search specific location master

### DIFF
--- a/app/assets/javascripts/wishlist.js
+++ b/app/assets/javascripts/wishlist.js
@@ -1,0 +1,11 @@
+function toggleOtherRestaurantsHeight() {
+  let container = document.getElementById("other-wishlists");
+  let element = document.getElementById("other-wishlists-heading");
+  if (container.style.height == "50px") {
+    container.style.height = "auto"
+    element.innerText = "[ - ] Other Locations"
+  } else {
+    container.style.height = "50px"
+    element.innerText = "[ + ] Other Locations"
+  }
+}

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -1,20 +1,25 @@
 class MatchesController < ApplicationController
 
   def index
-    if session[:locals].nil? || session[:locals].empty?
-      session[:locals] = current_user.local_restaurants(params[:location])
+    return unless params[:location] #render page without a facade if no location
+    session[:locals] = Hash.new unless session[:location] == params[:location] #reset session[:locals] if location has changed
+    session[:location] = params[:location] #save location in sessions
+    if session[:locals].nil? || session[:locals].empty? #if session[:locals] doesn't exist or is empty
+      session[:locals] = current_user.local_restaurants(params[:location]) #save restaurants in session[:locals]
     end
     @facade = MatchesFacade.new(current_user, session[:locals].shift.first)
+    redirect_to matches_path(location: session[:location]) if @facade.images.empty? #skip restaurants without photos
   end
 
   def create
     restaurant = Restaurant.create_self(params[:restaurant_info])
-    wishlist = current_user.wishlists.create(yelp_id: params[:restaurant_info][:id], restaurant_id: restaurant.id)
-    redirect_to matches_path
+    wishlist = current_user.wishlists.create(yelp_id: params[:restaurant_info][:id], 
+                                             restaurant_id: restaurant.id)
+    redirect_to matches_path(location: session[:location])
   end
 
   def destroy
-    redirect_to matches_path
+    redirect_to matches_path(location: session[:location])
   end
 
   def update

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -1,0 +1,6 @@
+class RestaurantsController < ApplicationController
+
+  def show
+    @restaurant = Restaurant.find(params[:id])
+  end
+end

--- a/app/controllers/wishlist_controller.rb
+++ b/app/controllers/wishlist_controller.rb
@@ -3,9 +3,7 @@ class WishlistController < ApplicationController
 
   def index
     four_oh_four if !current_user
-    @restaurants = current_user.wishlists.map do |wishlist|
-      wishlist.restaurant
-    end
+    @facade = WishlistFacade.new(current_user)
   end
 
 

--- a/app/facades/matches_facade.rb
+++ b/app/facades/matches_facade.rb
@@ -16,12 +16,6 @@ class MatchesFacade
     get_json
   end
 
-  # def restaurants
-  #   response = conn.get("search?term=restaurant&location=#{user.build_address}&radius=1609&limit=10&sort_by=distance")
-  #   body = JSON.parse(response.body, symbolize_names: true)
-  #   return body[:businesses]
-  # end
-
   private
 
   attr_reader :user

--- a/app/facades/wishlist_facade.rb
+++ b/app/facades/wishlist_facade.rb
@@ -1,0 +1,28 @@
+class WishlistFacade
+
+  def initialize(user)
+    @user = user
+  end
+
+  def restaurants
+    Restaurant.joins(:wishlists)
+              .where("wishlists.user_id = ?", user.id)
+  end
+
+  def default_restaurants
+    Restaurant.joins(:wishlists)
+              .where("wishlists.user_id = ?", user.id)
+              .where("restaurants.city = ?", user.default_city)
+  end
+
+  def other_restaurants
+    Restaurant.joins(:wishlists)
+              .where("wishlists.user_id = ?", user.id)
+              .where("restaurants.city != ?", user.default_city)
+  end
+
+  private
+
+  attr_reader :user
+
+end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -9,7 +9,8 @@ class Restaurant < ApplicationRecord
       phone_number: data[:display_phone],
       address:      data[:location][:display_address],
       name:         data[:name],
-      image:        data[:image_url]
+      image:        data[:image_url],
+      city:         "#{data[:location][:city]}, #{data[:location][:state]}"
     )
   end
 end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -9,7 +9,8 @@ class Restaurant < ApplicationRecord
       phone_number: restaurant_info[:display_phone],
       address: restaurant_info[:location][:display_address],
       name: restaurant_info[:name],
-      image: restaurant_info[:image_url]
+      image: restaurant_info[:image_url],
+      city: "#{restaurant_info[:location][:city]}, #{restaurant_info[:location][:state]}"
     )
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,10 @@ class User < ApplicationRecord
     [default.address, default.city, default.state, default.zip].compact.join(' ')
   end
 
+  def default_city
+    "#{main_address.city}, #{main_address.state}"
+  end
+
   def local_restaurants(location)
     response = conn.get("search?term=restaurant&location=#{location}&radius=1609&limit=20&sort_by=distance")
     body = JSON.parse(response.body, symbolize_names: true)
@@ -26,6 +30,8 @@ class User < ApplicationRecord
     end
     return restaurants
   end
+
+  private
 
   def conn
     Faraday.new(:url => "https://api.yelp.com/v3/businesses/") do |faraday|

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -15,5 +15,17 @@
       <%= button_to "Finish", finish_path, method: :patch,  class: "finish" %>
       <%= button_to "Pass", dislike_path, method: :delete, class: "dislike" %>
     </div>
+  <% else %>
+    <h2>No location specified.  Please specify a location or click "Default Location".</h2>
   <% end %>
 </main>
+<aside>
+  <div class="location-search-container">
+    <h3 >Specify a Location</h3> 
+    <%= form_tag(matches_path, method: "get") do %>
+      <%= label_tag(:location, "Search for:") %>
+      <%= text_field_tag(:location) %>
+      <%= submit_tag("Find Matches") %>
+    <% end %>
+  </div>
+</aside>

--- a/app/views/restaurants/show.html.erb
+++ b/app/views/restaurants/show.html.erb
@@ -1,0 +1,1 @@
+<h1><%= @restaurant.name %></h1>

--- a/app/views/wishlist/index.html.erb
+++ b/app/views/wishlist/index.html.erb
@@ -1,24 +1,47 @@
-<% if @restaurants.empty? %>
+<% if @facade.restaurants.empty? %>
 
   <h2>You don't have any recommended restaurants yet.</h2>
 
 <% else %>
 
   <h2>These are all the restaurants you've been interested in from the past.</h2>
-
-  <ul class="wishlists">
-    <% @restaurants.each do |restaurant| %>
-      <h3 class="restaurant_name"><%= restaurant.name %></h3>
-      <li class="restaurant_phone"><%= restaurant.phone_number %></li>
-      <li class="restaurant_address"><%=  JSON.parse(restaurant.address).join(' ') %></li>
-      <li class="restaurant_yelp_link"><%= restaurant.yelp_link %></li>
-      <li class="directions"><%= link_to "Get Directions", "/directions/#{restaurant.id}" %>
-      <img src=<%= restaurant.image %>
-           alt="restaurant or food photo"
-           class="photo"
-           width="300"
-           height="200" />
-    <% end %>
-  </ul>
-
+    <h3>Default City: <%= current_user.default_city %></h3>
+    <div class="default-wishlists">
+      <% @facade.default_restaurants.each do |restaurant| %>
+        <ul class="default-restaurant-<%= restaurant.id %>">
+          <h4 class="restaurant-name"><%= link_to restaurant.name, restaurant_path(restaurant.id) %></h4>
+          <li class="restaurant-phone"><%= restaurant.phone_number %></li>
+          <li class="restaurant-address"><%=  JSON.parse(restaurant.address).join(' ') %></li>
+          <li class="restaurant-yelp_link"><%= restaurant.yelp_link %></li>
+          <li class="directions"><%= link_to "Get Directions", "/directions/#{restaurant.id}" %>
+          <img src=<%= restaurant.image %>
+              alt="restaurant or food photo"
+              class="photo"
+              width="300"
+              height="200" />
+        </ul>
+      <% end %>
+    </div>
+    <div id="other-wishlists" style="height: 50px; overflow:hidden">
+      <h3 id="other-wishlists-heading"
+          onClick="toggleOtherRestaurantsHeight()">
+          [ + ] Other Locations
+      </h3>
+      <% @facade.other_restaurants.each do |restaurant| %>
+        <ul class="other-restaurant" id="other-restaurant-<%= restaurant.id %>">
+          <h4 class="restaurant-name">
+            <%= link_to restaurant.name, restaurant_path(restaurant.id) %>
+          </h4>
+          <li class="restaurant-phone"><%= restaurant.phone_number %></li>
+          <li class="restaurant-address"><%=  JSON.parse(restaurant.address).join(' ') %></li>
+          <li class="restaurant-yelp_link"><%= restaurant.yelp_link %></li>
+          <li class="directions"><%= link_to "Get Directions", "/directions/#{restaurant.id}" %>
+          <img src=<%= restaurant.image %>
+              alt="restaurant or food photo"
+              class="photo"
+              width="300"
+              height="200" />
+        </ul>
+      <% end %>
+    </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,7 @@ Rails.application.routes.draw do
     resources :main_addresses, only: [:create, :destroy, :edit, :update]
   end
 
+  resources :restaurants, only: [:show]
+
   get '/directions/:id', to: 'directions#show'
 end

--- a/db/migrate/20181223043040_create_restaurants.rb
+++ b/db/migrate/20181223043040_create_restaurants.rb
@@ -8,6 +8,7 @@ class CreateRestaurants < ActiveRecord::Migration[5.2]
       t.string :address
       t.string :name
       t.string :image
+      t.string :city
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2018_12_23_082807) do
     t.string "address"
     t.string "name"
     t.string "image"
+    t.string "city"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/cassettes/geocode_lookup.yml
+++ b/spec/cassettes/geocode_lookup.yml
@@ -63,7 +63,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 23 Dec 2018 17:10:06 GMT
+      - Mon, 24 Dec 2018 02:53:21 GMT
       Server:
       - Apache/2.4.29 (Ubuntu)
       Access-Control-Allow-Origin:
@@ -86,7 +86,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Sun, 23 Dec 2018 17:10:06 GMT
+  recorded_at: Mon, 24 Dec 2018 02:53:21 GMT
 - request:
     method: get
     uri: https://nominatim.openstreetmap.org/search?accept-language=en&addressdetails=1&format=json&q=17th%20St%20LL100%20Denver%20CO%2080202
@@ -106,7 +106,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 23 Dec 2018 17:10:08 GMT
+      - Mon, 24 Dec 2018 02:53:22 GMT
       Server:
       - Apache/2.4.29 (Ubuntu)
       Access-Control-Allow-Origin:
@@ -129,5 +129,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Sun, 23 Dec 2018 17:10:08 GMT
+  recorded_at: Mon, 24 Dec 2018 02:53:22 GMT
 recorded_with: VCR 4.0.0

--- a/spec/features/matches/registered_user_searches_default_location_spec.rb
+++ b/spec/features/matches/registered_user_searches_default_location_spec.rb
@@ -61,11 +61,12 @@ describe 'As a registered user' do
           end
 
           it "should display restaurant info in my wishlist" do
+            save_and_open_page
             expect(page).to have_content("These are all the restaurants you've been interested in from the past.")
-            expect(page).to have_css("h3.restaurant_name", count: 1)
-            expect(page).to have_css("li.restaurant_address", count: 1)
-            expect(page).to have_css("li.restaurant_phone", count: 1)
-            expect(page).to have_css("li.restaurant_yelp_link", count: 1)
+            expect(page).to have_css("h4.restaurant-name", count: 1)
+            expect(page).to have_css("li.restaurant-address", count: 1)
+            expect(page).to have_css("li.restaurant-phone", count: 1)
+            expect(page).to have_css("li.restaurant-yelp_link", count: 1)
             expect(page).to have_css("img.photo", count: 1)
           end
         end

--- a/spec/features/matches/registered_user_searches_default_location_spec.rb
+++ b/spec/features/matches/registered_user_searches_default_location_spec.rb
@@ -61,7 +61,6 @@ describe 'As a registered user' do
           end
 
           it "should display restaurant info in my wishlist" do
-            save_and_open_page
             expect(page).to have_content("These are all the restaurants you've been interested in from the past.")
             expect(page).to have_css("h4.restaurant-name", count: 1)
             expect(page).to have_css("li.restaurant-address", count: 1)

--- a/spec/features/matches/registered_user_searches_default_location_spec.rb
+++ b/spec/features/matches/registered_user_searches_default_location_spec.rb
@@ -37,7 +37,7 @@ describe 'As a registered user' do
       it 'should display photos and like and dislike buttons' do
 
         expect(current_path).to eq("/matches")
-        expect(page).to have_css(".photo", count: 3)
+        expect(page).to have_css(".photo")
         expect(page).to have_css("input.like", count: 1)
         expect(page).to have_css("input.dislike", count: 1)
         expect(page).to have_css("input.finish", count: 1)
@@ -46,13 +46,12 @@ describe 'As a registered user' do
       describe "when I click the like button" do
 
         before(:each) do
-          visit matches_path
           click_on "Like"
         end
 
         it "should display a new set of photos" do
           expect(current_path).to eq("/matches")
-          expect(page).to have_css(".photo", count: 3)
+          expect(page).to have_css(".photo")
         end
 
         describe "when I click the finish button" do
@@ -75,13 +74,12 @@ describe 'As a registered user' do
       describe "when I click the dislike button" do
 
         before(:each) do
-          visit matches_path
           click_on "Pass"
         end
 
         it "should display a new set of photos" do
           expect(current_path).to eq("/matches")
-          expect(page).to have_css(".photo", count: 3)
+          expect(page).to have_css(".photo")
         end
 
         describe "when I click the finish button" do

--- a/spec/features/matches/registered_user_searches_specific_location_spec.rb
+++ b/spec/features/matches/registered_user_searches_specific_location_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+describe 'As a registered user' do
+
+  before(:each) do
+    VCR.use_cassette('geocode_lookup') do
+      user = create(:user)
+      address = create(:main_address, user: user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    end
+  end
+
+  describe 'when I visit the restaurant search path' do
+
+    before(:each) do
+      visit matches_path
+    end
+
+    it 'should display a form to search using a specified location' do
+      expect(page).to have_content("Specify a Location")
+      expect(page).to have_content("Search for:")
+    end
+
+    describe 'when I enter a complete address and click search' do
+
+      before(:each) do
+        stub_request(:get, "https://api.yelp.com/v3/businesses/search?limit=20&location=1634%2018th%20St,%20Denver,%20CO%2080202&radius=1609&sort_by=distance&term=restaurant").
+          to_return(body: File.read("./spec/fixtures/business_search_specific.json"))
+        stub_request(:get, "https://api.yelp.com/v3/businesses/AufxrKk-COzfAMr9KMVWRA").
+          to_return(body: File.read("./spec/fixtures/business_details_4.json"))
+        # stub_request(:get, "https://api.yelp.com/v3/businesses/IFVAm31yNaKw5_Sa1TuP4g").
+        #   to_return(body: File.read("./spec/fixtures/business_details_5.json"))
+        # stub_request(:get, "https://api.yelp.com/v3/businesses/us9NRKZDQZH0iKgEmdhbJQ").
+        #   to_return(body: File.read("./spec/fixtures/business_details_6.json"))
+        fill_in "Search for:", with: "1634 18th St, Denver, CO 80202"
+        click_on "Find Matches"
+      end
+
+      it 'should display photos and like and dislike buttons' do
+
+        expect(current_path).to eq("/matches")
+        expect(page).to have_css(".photo")
+        expect(page).to have_css("input.like", count: 1)
+        expect(page).to have_css("input.dislike", count: 1)
+        expect(page).to have_css("input.finish", count: 1)
+      end
+    end
+
+    describe 'when I enter a city/state and click search' do
+
+      before(:each) do
+        stub_request(:get, "https://api.yelp.com/v3/businesses/search?limit=20&location=Denver,%20CO&radius=1609&sort_by=distance&term=restaurant").
+          to_return(body: File.read("./spec/fixtures/business_search_city_state.json"))
+        stub_request(:get, "https://api.yelp.com/v3/businesses/mKRMTGAOQKPIdhi8LKB4Tg").
+          to_return(body: File.read("./spec/fixtures/business_details_7.json"))
+        # stub_request(:get, "https://api.yelp.com/v3/businesses/eaVcCJO5OmBhAv-kJRpWRg").
+        #   to_return(body: File.read("./spec/fixtures/business_details_8.json"))
+        # stub_request(:get, "https://api.yelp.com/v3/businesses/us9NRKZDQZH0iKgEmdhbJQ").
+        #   to_return(body: File.read("./spec/fixtures/business_details_9.json"))
+        fill_in "Search for:", with: "Denver, CO"
+        click_on "Find Matches"
+      end
+
+      it 'should display photos and like and dislike buttons' do
+
+        expect(current_path).to eq("/matches")
+        expect(page).to have_css(".photo")
+        expect(page).to have_css("input.like", count: 1)
+        expect(page).to have_css("input.dislike", count: 1)
+        expect(page).to have_css("input.finish", count: 1)
+      end
+    end
+
+    describe 'when I enter a zip code and click search' do
+
+      before(:each) do
+        stub_request(:get, "https://api.yelp.com/v3/businesses/search?limit=20&location=80202&radius=1609&sort_by=distance&term=restaurant").
+          to_return(body: File.read("./spec/fixtures/business_search_zip.json"))
+        stub_request(:get, "https://api.yelp.com/v3/businesses/idKs48V1lf8LQwvcFJjzGg").
+          to_return(body: File.read("./spec/fixtures/business_details_8.json"))
+        stub_request(:get, "https://api.yelp.com/v3/businesses/9EBwv92qSn1aFTZ-oK1wag").
+          to_return(body: File.read("./spec/fixtures/business_details_9.json"))
+        # stub_request(:get, "https://api.yelp.com/v3/businesses/us9NRKZDQZH0iKgEmdhbJQ").
+        #   to_return(body: File.read("./spec/fixtures/business_details_6.json"))
+        fill_in "Search for:", with: "80202"
+        click_on "Find Matches"
+      end
+
+      it 'should display photos and like and dislike buttons' do
+
+        expect(current_path).to eq("/matches")
+        expect(page).to have_css(".photo")
+        expect(page).to have_css("input.like", count: 1)
+        expect(page).to have_css("input.dislike", count: 1)
+        expect(page).to have_css("input.finish", count: 1)
+      end
+
+    end
+  end
+end

--- a/spec/features/matches/registered_user_searches_specific_location_spec.rb
+++ b/spec/features/matches/registered_user_searches_specific_location_spec.rb
@@ -28,10 +28,6 @@ describe 'As a registered user' do
           to_return(body: File.read("./spec/fixtures/business_search_specific.json"))
         stub_request(:get, "https://api.yelp.com/v3/businesses/AufxrKk-COzfAMr9KMVWRA").
           to_return(body: File.read("./spec/fixtures/business_details_4.json"))
-        # stub_request(:get, "https://api.yelp.com/v3/businesses/IFVAm31yNaKw5_Sa1TuP4g").
-        #   to_return(body: File.read("./spec/fixtures/business_details_5.json"))
-        # stub_request(:get, "https://api.yelp.com/v3/businesses/us9NRKZDQZH0iKgEmdhbJQ").
-        #   to_return(body: File.read("./spec/fixtures/business_details_6.json"))
         fill_in "Search for:", with: "1634 18th St, Denver, CO 80202"
         click_on "Find Matches"
       end
@@ -53,10 +49,6 @@ describe 'As a registered user' do
           to_return(body: File.read("./spec/fixtures/business_search_city_state.json"))
         stub_request(:get, "https://api.yelp.com/v3/businesses/mKRMTGAOQKPIdhi8LKB4Tg").
           to_return(body: File.read("./spec/fixtures/business_details_7.json"))
-        # stub_request(:get, "https://api.yelp.com/v3/businesses/eaVcCJO5OmBhAv-kJRpWRg").
-        #   to_return(body: File.read("./spec/fixtures/business_details_8.json"))
-        # stub_request(:get, "https://api.yelp.com/v3/businesses/us9NRKZDQZH0iKgEmdhbJQ").
-        #   to_return(body: File.read("./spec/fixtures/business_details_9.json"))
         fill_in "Search for:", with: "Denver, CO"
         click_on "Find Matches"
       end

--- a/spec/features/wishlist/user_can_see_their_wishlist_spec.rb
+++ b/spec/features/wishlist/user_can_see_their_wishlist_spec.rb
@@ -11,16 +11,58 @@ describe 'Wishlist' do
 
   describe "User" do
 
-    it 'A User can visit wishlist index' do
+    before(:each) do
+      VCR.use_cassette('geocode_lookup') do
+        stub_request(:get, "https://api.yelp.com/v3/businesses/cL8rbKfItlQOoFzLIQAsdA").
+          to_return(body: File.read("./spec/fixtures/business_details_1.json"))
+        stub_request(:get, "https://api.yelp.com/v3/businesses/eaVcCJO5OmBhAv-kJRpWRg").
+          to_return(body: File.read("./spec/fixtures/business_details_2.json"))
+        stub_request(:get, "https://api.yelp.com/v3/businesses/KPQ1fifN8sVnINat4xmDXQ").
+          to_return(body: File.read("./spec/fixtures/business_details_10.json"))
+        user = create(:user)
+        address = create(:main_address, user: user)
+        facade_1 = MatchesFacade.new(user, "cL8rbKfItlQOoFzLIQAsdA")
+        facade_2 = MatchesFacade.new(user, "eaVcCJO5OmBhAv-kJRpWRg")
+        facade_3 = MatchesFacade.new(user, "KPQ1fifN8sVnINat4xmDXQ")
+        @restaurant_1 = Restaurant.create_self(facade_1.restaurant_info)
+        @restaurant_2 = Restaurant.create_self(facade_2.restaurant_info)
+        @restaurant_3 = Restaurant.create_self(facade_3.restaurant_info)
+        user.wishlists.create(yelp_id: facade_1.restaurant_info[:id], restaurant_id: @restaurant_1.id)
+        user.wishlists.create(yelp_id: facade_2.restaurant_info[:id], restaurant_id: @restaurant_2.id)
+        user.wishlists.create(yelp_id: facade_3.restaurant_info[:id], restaurant_id: @restaurant_3.id)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+        visit wishlist_path
+      end
+    end
 
+    it 'A User can visit wishlist index' do
+      expect(current_path).to eq(wishlist_path)
     end
 
     it 'Wishlist Item cards are links to restaurant show' do
+      click_on @restaurant_1.name
 
-
+      expect(current_path).to eq("/restaurants/#{@restaurant_1.id}")
+      expect(page).to have_content(@restaurant_1.name)
+      expect(page).to_not have_content(@restaurant_2.name)
+      expect(page).to_not have_content(@restaurant_3.name)
     end
 
+    xit "Only wishlist items in my default location city are visible" do
+      expect(page).to have_content(@restaurant_1.name)
+      expect(page).to have_content(@restaurant_1.phone_number)
+      expect(page).to have_content(@restaurant_2.name)
+      expect(page).to have_content(@restaurant_2.phone_number)
+      expect(page).to_not have_content(@restaurant_3.name)
+      expect(page).to_not have_content(@restaurant_3.phone_number)
+    end
 
+    xit "Displays wishlist items from other cities when I click expand" do
+      click_on("Aurora, CO")
+
+      expect(page).to have_content(@restaurant_3.name)
+      expect(page).to have_content(@restaurant_3.city)
+    end
 
   end
 

--- a/spec/fixtures/business_details_10.json
+++ b/spec/fixtures/business_details_10.json
@@ -1,0 +1,87 @@
+{
+  "id": "KPQ1fifN8sVnINat4xmDXQ",
+  "alias": "jaidens-neveria-y-antojitos-aurora",
+  "name": "Jaiden's Neveria Y Antojitos",
+  "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/2iHVjGqqVRvEv6QvsWs0gg/o.jpg",
+  "is_claimed": false,
+  "is_closed": false,
+  "url": "https://www.yelp.com/biz/jaidens-neveria-y-antojitos-aurora?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+  "phone": "+17206688933",
+  "display_phone": "(720) 668-8933",
+  "review_count": 2,
+  "categories": [
+    {
+      "alias": "mexican",
+      "title": "Mexican"
+    }
+  ],
+  "rating": 5,
+  "location": {
+    "address1": "1746 S Chambers Rd",
+    "address2": "",
+    "address3": null,
+    "city": "Aurora",
+    "zip_code": "80017",
+    "country": "US",
+    "state": "CO",
+    "display_address": [
+      "1746 S Chambers Rd",
+      "Aurora, CO 80017"
+    ],
+    "cross_streets": ""
+  },
+  "coordinates": {
+    "latitude": 39.6844386,
+    "longitude": -104.8096951
+  },
+  "photos": [
+    "https://s3-media1.fl.yelpcdn.com/bphoto/2iHVjGqqVRvEv6QvsWs0gg/o.jpg",
+    "https://s3-media2.fl.yelpcdn.com/bphoto/VeqS9Sph8sUKn9f07snJKw/o.jpg",
+    "https://s3-media2.fl.yelpcdn.com/bphoto/mQWXWGOxpN0gE-Y9PpfRHg/o.jpg"
+  ],
+  "hours": [
+    {
+      "open": [
+        {
+          "is_overnight": false,
+          "start": "1100",
+          "end": "2000",
+          "day": 1
+        },
+        {
+          "is_overnight": false,
+          "start": "1100",
+          "end": "2000",
+          "day": 2
+        },
+        {
+          "is_overnight": false,
+          "start": "1100",
+          "end": "2000",
+          "day": 3
+        },
+        {
+          "is_overnight": false,
+          "start": "1100",
+          "end": "2000",
+          "day": 4
+        },
+        {
+          "is_overnight": false,
+          "start": "1100",
+          "end": "2000",
+          "day": 5
+        },
+        {
+          "is_overnight": false,
+          "start": "1100",
+          "end": "2000",
+          "day": 6
+        }
+      ],
+      "hours_type": "REGULAR",
+      "is_open_now": true
+    }
+  ],
+  "transactions": []
+}

--- a/spec/fixtures/business_details_4.json
+++ b/spec/fixtures/business_details_4.json
@@ -1,0 +1,102 @@
+{
+  "id": "AufxrKk-COzfAMr9KMVWRA",
+  "alias": "mortons-the-steakhouse-denver-2",
+  "name": "Morton's The Steakhouse",
+  "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/c86oV0nZkTOm2Pt9tKFYog/o.jpg",
+  "is_claimed": true,
+  "is_closed": false,
+  "url": "https://www.yelp.com/biz/mortons-the-steakhouse-denver-2?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+  "phone": "+13038253353",
+  "display_phone": "(303) 825-3353",
+  "review_count": 168,
+  "categories": [
+    {
+      "alias": "steak",
+      "title": "Steakhouses"
+    },
+    {
+      "alias": "tradamerican",
+      "title": "American (Traditional)"
+    },
+    {
+      "alias": "bars",
+      "title": "Bars"
+    }
+  ],
+  "rating": 3.5,
+  "location": {
+    "address1": "1745 Wazee St",
+    "address2": "",
+    "address3": "",
+    "city": "Denver",
+    "zip_code": "80202",
+    "country": "US",
+    "state": "CO",
+    "display_address": [
+      "1745 Wazee St",
+      "Denver, CO 80202"
+    ],
+    "cross_streets": ""
+  },
+  "coordinates": {
+    "latitude": 39.7530570684622,
+    "longitude": -104.998126650297
+  },
+  "photos": [
+    "https://s3-media3.fl.yelpcdn.com/bphoto/c86oV0nZkTOm2Pt9tKFYog/o.jpg",
+    "https://s3-media4.fl.yelpcdn.com/bphoto/wAA56X2hIEfHlibfOqyX8Q/o.jpg",
+    "https://s3-media3.fl.yelpcdn.com/bphoto/tEoR8CZTV79iO8a87Qe5MQ/o.jpg"
+  ],
+  "price": "$$$$",
+  "hours": [
+    {
+      "open": [
+        {
+          "is_overnight": false,
+          "start": "1700",
+          "end": "2200",
+          "day": 0
+        },
+        {
+          "is_overnight": false,
+          "start": "1700",
+          "end": "2200",
+          "day": 1
+        },
+        {
+          "is_overnight": false,
+          "start": "1700",
+          "end": "2200",
+          "day": 2
+        },
+        {
+          "is_overnight": false,
+          "start": "1700",
+          "end": "2200",
+          "day": 3
+        },
+        {
+          "is_overnight": false,
+          "start": "1700",
+          "end": "2300",
+          "day": 4
+        },
+        {
+          "is_overnight": false,
+          "start": "1700",
+          "end": "2300",
+          "day": 5
+        },
+        {
+          "is_overnight": false,
+          "start": "1700",
+          "end": "2200",
+          "day": 6
+        }
+      ],
+      "hours_type": "REGULAR",
+      "is_open_now": false
+    }
+  ],
+  "transactions": []
+}

--- a/spec/fixtures/business_details_5.json
+++ b/spec/fixtures/business_details_5.json
@@ -1,0 +1,102 @@
+{
+  "id": "IFVAm31yNaKw5_Sa1TuP4g",
+  "alias": "rodizio-grill-denver-denver",
+  "name": "Rodizio Grill Denver",
+  "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/_fcMX4Gnhocq_Gd1QQANWA/o.jpg",
+  "is_claimed": true,
+  "is_closed": false,
+  "url": "https://www.yelp.com/biz/rodizio-grill-denver-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+  "phone": "+13032949277",
+  "display_phone": "(303) 294-9277",
+  "review_count": 412,
+  "categories": [
+    {
+      "alias": "steak",
+      "title": "Steakhouses"
+    },
+    {
+      "alias": "brazilian",
+      "title": "Brazilian"
+    },
+    {
+      "alias": "buffets",
+      "title": "Buffets"
+    }
+  ],
+  "rating": 3.5,
+  "location": {
+    "address1": "1801 Wynkoop St",
+    "address2": "",
+    "address3": "",
+    "city": "Denver",
+    "zip_code": "80202",
+    "country": "US",
+    "state": "CO",
+    "display_address": [
+      "1801 Wynkoop St",
+      "Denver, CO 80202"
+    ],
+    "cross_streets": ""
+  },
+  "coordinates": {
+    "latitude": 39.7539989260745,
+    "longitude": -104.998431005314
+  },
+  "photos": [
+    "https://s3-media1.fl.yelpcdn.com/bphoto/_fcMX4Gnhocq_Gd1QQANWA/o.jpg",
+    "https://s3-media2.fl.yelpcdn.com/bphoto/j7iDpQSAVXjEIzgv7DgmzQ/o.jpg",
+    "https://s3-media4.fl.yelpcdn.com/bphoto/vhY-nLO8TpO1ZDFd945hug/o.jpg"
+  ],
+  "price": "$$$",
+  "hours": [
+    {
+      "open": [
+        {
+          "is_overnight": false,
+          "start": "1630",
+          "end": "2100",
+          "day": 0
+        },
+        {
+          "is_overnight": false,
+          "start": "1630",
+          "end": "2100",
+          "day": 1
+        },
+        {
+          "is_overnight": false,
+          "start": "1630",
+          "end": "2100",
+          "day": 2
+        },
+        {
+          "is_overnight": false,
+          "start": "1630",
+          "end": "2100",
+          "day": 3
+        },
+        {
+          "is_overnight": false,
+          "start": "1130",
+          "end": "2200",
+          "day": 4
+        },
+        {
+          "is_overnight": false,
+          "start": "1130",
+          "end": "2200",
+          "day": 5
+        },
+        {
+          "is_overnight": false,
+          "start": "1130",
+          "end": "2100",
+          "day": 6
+        }
+      ],
+      "hours_type": "REGULAR",
+      "is_open_now": true
+    }
+  ],
+  "transactions": []
+}

--- a/spec/fixtures/business_details_6.json
+++ b/spec/fixtures/business_details_6.json
@@ -1,0 +1,96 @@
+  {
+    "id": "mzOAkvH-4WIfQuR3uCs87g",
+    "alias": "hopdoddy-burger-bar-denver",
+    "name": "Hopdoddy Burger Bar",
+    "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/CdADjEj_McY9D9Mpk6Jvgg/o.jpg",
+    "is_claimed": true,
+    "is_closed": false,
+    "url": "https://www.yelp.com/biz/hopdoddy-burger-bar-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+    "phone": "+13034462337",
+    "display_phone": "(303) 446-2337",
+    "review_count": 756,
+    "categories": [
+      {
+        "alias": "burgers",
+        "title": "Burgers"
+      }
+    ],
+    "rating": 4.5,
+    "location": {
+      "address1": "1747 Wynkoop St",
+      "address2": "",
+      "address3": "",
+      "city": "Denver",
+      "zip_code": "80202",
+      "country": "US",
+      "state": "CO",
+      "display_address": [
+        "1747 Wynkoop St",
+        "Denver, CO 80202"
+      ],
+      "cross_streets": ""
+    },
+    "coordinates": {
+      "latitude": 39.7534294,
+      "longitude": -104.9991989
+    },
+    "photos": [
+      "https://s3-media1.fl.yelpcdn.com/bphoto/CdADjEj_McY9D9Mpk6Jvgg/o.jpg",
+      "https://s3-media4.fl.yelpcdn.com/bphoto/KQGsi63Bi2MHD7xxcm1CUw/o.jpg",
+      "https://s3-media4.fl.yelpcdn.com/bphoto/-0UCieO-8UoHjnaD_RT_KQ/o.jpg"
+    ],
+    "price": "$$",
+    "hours": [
+      {
+        "open": [
+          {
+            "is_overnight": false,
+            "start": "1100",
+            "end": "2200",
+            "day": 0
+          },
+          {
+            "is_overnight": false,
+            "start": "1100",
+            "end": "2200",
+            "day": 1
+          },
+          {
+            "is_overnight": false,
+            "start": "1100",
+            "end": "2200",
+            "day": 2
+          },
+          {
+            "is_overnight": false,
+            "start": "1100",
+            "end": "2200",
+            "day": 3
+          },
+          {
+            "is_overnight": false,
+            "start": "1100",
+            "end": "2300",
+            "day": 4
+          },
+          {
+            "is_overnight": false,
+            "start": "1100",
+            "end": "2300",
+            "day": 5
+          },
+          {
+            "is_overnight": false,
+            "start": "1100",
+            "end": "2200",
+            "day": 6
+          }
+        ],
+        "hours_type": "REGULAR",
+        "is_open_now": true
+      }
+    ],
+    "transactions": [
+      "pickup"
+    ]
+  }

--- a/spec/fixtures/business_details_7.json
+++ b/spec/fixtures/business_details_7.json
@@ -1,0 +1,97 @@
+{
+  "id": "mKRMTGAOQKPIdhi8LKB4Tg",
+  "alias": "little-gingko-asian-cafe-denver-2",
+  "name": "Little Gingko Asian Cafe",
+  "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/NUE5hIaTPzlsKOnDaVSCAg/o.jpg",
+  "is_claimed": true,
+  "is_closed": false,
+  "url": "https://www.yelp.com/biz/little-gingko-asian-cafe-denver-2?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+  "phone": "+13039932327",
+  "display_phone": "(303) 993-2327",
+  "review_count": 67,
+  "categories": [
+    {
+      "alias": "chinese",
+      "title": "Chinese"
+    }
+  ],
+  "rating": 4,
+  "location": {
+    "address1": "1279 N Marion St",
+    "address2": "",
+    "address3": null,
+    "city": "Denver",
+    "zip_code": "80218",
+    "country": "US",
+    "state": "CO",
+    "display_address": [
+      "1279 N Marion St",
+      "Denver, CO 80218"
+    ],
+    "cross_streets": ""
+  },
+  "coordinates": {
+    "latitude": 39.7366885730926,
+    "longitude": -104.972055974762
+  },
+  "photos": [
+    "https://s3-media2.fl.yelpcdn.com/bphoto/NUE5hIaTPzlsKOnDaVSCAg/o.jpg",
+    "https://s3-media2.fl.yelpcdn.com/bphoto/6i1iavaRvOxpnn5HbJOwRQ/o.jpg",
+    "https://s3-media1.fl.yelpcdn.com/bphoto/fctw95hpmkz4I1nVRrgYsA/o.jpg"
+  ],
+  "price": "$$",
+  "hours": [
+    {
+      "open": [
+        {
+          "is_overnight": false,
+          "start": "1100",
+          "end": "2200",
+          "day": 0
+        },
+        {
+          "is_overnight": false,
+          "start": "1100",
+          "end": "2200",
+          "day": 1
+        },
+        {
+          "is_overnight": false,
+          "start": "1100",
+          "end": "2200",
+          "day": 2
+        },
+        {
+          "is_overnight": false,
+          "start": "1100",
+          "end": "2200",
+          "day": 3
+        },
+        {
+          "is_overnight": false,
+          "start": "1100",
+          "end": "2230",
+          "day": 4
+        },
+        {
+          "is_overnight": false,
+          "start": "1130",
+          "end": "2230",
+          "day": 5
+        },
+        {
+          "is_overnight": false,
+          "start": "1130",
+          "end": "2200",
+          "day": 6
+        }
+      ],
+      "hours_type": "REGULAR",
+      "is_open_now": true
+    }
+  ],
+  "transactions": [
+    "delivery",
+    "pickup"
+  ]
+}

--- a/spec/fixtures/business_details_8.json
+++ b/spec/fixtures/business_details_8.json
@@ -1,0 +1,49 @@
+{
+  "id": "idKs48V1lf8LQwvcFJjzGg",
+  "alias": "ali-baba-halal-denver",
+  "name": "Ali Baba Halal",
+  "image_url": "",
+  "is_claimed": false,
+  "is_closed": false,
+  "url": "https://www.yelp.com/biz/ali-baba-halal-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+  "phone": "",
+  "display_phone": "",
+  "review_count": 1,
+  "categories": [
+    {
+      "alias": "streetvendors",
+      "title": "Street Vendors"
+    },
+    {
+      "alias": "burgers",
+      "title": "Burgers"
+    },
+    {
+      "alias": "mideastern",
+      "title": "Middle Eastern"
+    }
+  ],
+  "rating": 3,
+  "location": {
+    "address1": "Food Cart",
+    "address2": "",
+    "address3": "Civic Center Station - Colfax & Broadway",
+    "city": "Denver",
+    "zip_code": "80202",
+    "country": "US",
+    "state": "CO",
+    "display_address": [
+      "Food Cart",
+      "Civic Center Station - Colfax & Broadway",
+      "Denver, CO 80202"
+    ],
+    "cross_streets": ""
+  },
+  "coordinates": {
+    "latitude": 39.7430327,
+    "longitude": -104.9873792
+  },
+  "photos": [],
+  "price": "$$",
+  "transactions": []
+}

--- a/spec/fixtures/business_details_9.json
+++ b/spec/fixtures/business_details_9.json
@@ -1,0 +1,42 @@
+{
+  "id": "9EBwv92qSn1aFTZ-oK1wag",
+  "alias": "sandwich-board-denver-3",
+  "name": "Sandwich Board",
+  "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/C6rxwuCEQudhxZtVHq6-Xg/o.jpg",
+  "is_claimed": false,
+  "is_closed": false,
+  "url": "https://www.yelp.com/biz/sandwich-board-denver-3?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+  "phone": "+13038614280",
+  "display_phone": "(303) 861-4280",
+  "review_count": 8,
+  "categories": [
+    {
+      "alias": "sandwiches",
+      "title": "Sandwiches"
+    }
+  ],
+  "rating": 3,
+  "location": {
+    "address1": "1740 Broadway",
+    "address2": "",
+    "address3": "",
+    "city": "Denver",
+    "zip_code": "80274",
+    "country": "US",
+    "state": "CO",
+    "display_address": [
+      "1740 Broadway",
+      "Denver, CO 80274"
+    ],
+    "cross_streets": ""
+  },
+  "coordinates": {
+    "latitude": 39.7440567016602,
+    "longitude": -104.986724853516
+  },
+  "photos": [
+    "https://s3-media3.fl.yelpcdn.com/bphoto/C6rxwuCEQudhxZtVHq6-Xg/o.jpg"
+  ],
+  "price": "$",
+  "transactions": []
+}

--- a/spec/fixtures/business_search_city_state.json
+++ b/spec/fixtures/business_search_city_state.json
@@ -1,0 +1,923 @@
+{
+  "businesses": [
+    {
+      "id": "mKRMTGAOQKPIdhi8LKB4Tg",
+      "alias": "little-gingko-asian-cafe-denver-2",
+      "name": "Little Gingko Asian Cafe",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/NUE5hIaTPzlsKOnDaVSCAg/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/little-gingko-asian-cafe-denver-2?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 67,
+      "categories": [
+        {
+          "alias": "chinese",
+          "title": "Chinese"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.7366885730926,
+        "longitude": -104.972055974762
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$$",
+      "location": {
+        "address1": "1279 N Marion St",
+        "address2": "",
+        "address3": null,
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1279 N Marion St",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+13039932327",
+      "display_phone": "(303) 993-2327",
+      "distance": 201.82367349684125
+    },
+    {
+      "id": "e5OmZc9oLQ8iTqBJ6DFEaQ",
+      "alias": "nicolos-pizza-denver",
+      "name": "Nicolo's Pizza",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/u1jlYQtqaAVWW7TIJAl6Gg/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/nicolos-pizza-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 228,
+      "categories": [
+        {
+          "alias": "pizza",
+          "title": "Pizza"
+        },
+        {
+          "alias": "italian",
+          "title": "Italian"
+        },
+        {
+          "alias": "sportsbars",
+          "title": "Sports Bars"
+        }
+      ],
+      "rating": 3,
+      "coordinates": {
+        "latitude": 39.73699,
+        "longitude": -104.97265
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$$",
+      "location": {
+        "address1": "1209 E 13th Ave",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1209 E 13th Ave",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+13038317000",
+      "display_phone": "(303) 831-7000",
+      "distance": 258.04503323335985
+    },
+    {
+      "id": "-vpzhgC8GRKGPkSdBEs57A",
+      "alias": "thump-coffee-denver",
+      "name": "Thump Coffee",
+      "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/Yc_6yxzOEQR9fykjGsmsXA/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/thump-coffee-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 438,
+      "categories": [
+        {
+          "alias": "coffee",
+          "title": "Coffee & Tea"
+        },
+        {
+          "alias": "breakfast_brunch",
+          "title": "Breakfast & Brunch"
+        },
+        {
+          "alias": "sandwiches",
+          "title": "Sandwiches"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.7370258977843,
+        "longitude": -104.972867249372
+      },
+      "transactions": [],
+      "price": "$",
+      "location": {
+        "address1": "1201 E 13th Ave",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1201 E 13th Ave",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+17204566648",
+      "display_phone": "(720) 456-6648",
+      "distance": 279.54377223900553
+    },
+    {
+      "id": "WwY6Gv6aOsvkgBZWRwKQ3g",
+      "alias": "island-bowls-denver",
+      "name": "Island Bowls",
+      "image_url": "",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/island-bowls-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 1,
+      "categories": [
+        {
+          "alias": "hawaiian",
+          "title": "Hawaiian"
+        },
+        {
+          "alias": "foodtrucks",
+          "title": "Food Trucks"
+        }
+      ],
+      "rating": 5,
+      "coordinates": {
+        "latitude": 39.7355804443359,
+        "longitude": -104.797088623047
+      },
+      "transactions": [],
+      "location": {
+        "address1": "123 Mobile St",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "123 Mobile St",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+18086342142",
+      "display_phone": "(808) 634-2142",
+      "distance": 315.8072509197713
+    },
+    {
+      "id": "Nc0A4vZK_kMvYNYX7vVrAw",
+      "alias": "snarfs-sandwiches-denver-2",
+      "name": "Snarf's Sandwiches",
+      "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/oDQJnGFcid1NitpXHoXGQA/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/snarfs-sandwiches-denver-2?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 542,
+      "categories": [
+        {
+          "alias": "sandwiches",
+          "title": "Sandwiches"
+        },
+        {
+          "alias": "salad",
+          "title": "Salad"
+        },
+        {
+          "alias": "italian",
+          "title": "Italian"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.73393,
+        "longitude": -104.97495
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$",
+      "location": {
+        "address1": "1001 E 11th Ave",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1001 E 11th Ave",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+13038329999",
+      "display_phone": "(303) 832-9999",
+      "distance": 434.3705687851355
+    },
+    {
+      "id": "4LSF_BgZdsNTWr-nqHBeow",
+      "alias": "sexy-pizza-denver",
+      "name": "Sexy Pizza",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/IUEZlRzsh8CM6AH8VB19cw/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/sexy-pizza-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 468,
+      "categories": [
+        {
+          "alias": "pizza",
+          "title": "Pizza"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.73355,
+        "longitude": -104.97483
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$",
+      "location": {
+        "address1": "1018 E 11th Ave",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1018 E 11th Ave",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+13038308111",
+      "display_phone": "(303) 830-8111",
+      "distance": 448.7273085594925
+    },
+    {
+      "id": "nEkozXuzcppMc5xXNJ1WBA",
+      "alias": "wokano-asian-bistro-denver-2",
+      "name": "Wokano Asian Bistro",
+      "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/De3p49LpqFd17QZwjWFi5A/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/wokano-asian-bistro-denver-2?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 447,
+      "categories": [
+        {
+          "alias": "asianfusion",
+          "title": "Asian Fusion"
+        },
+        {
+          "alias": "coffee",
+          "title": "Coffee & Tea"
+        },
+        {
+          "alias": "wraps",
+          "title": "Wraps"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.7334,
+        "longitude": -104.975
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$$",
+      "location": {
+        "address1": "1078 Ogden St",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1078 Ogden St",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+13038318277",
+      "display_phone": "(303) 831-8277",
+      "distance": 466.1235750653916
+    },
+    {
+      "id": "Ghisg_dtjnyWSQ_UO3fPig",
+      "alias": "barricudas-denver-3",
+      "name": "Barricuda's",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/hbvhTyt34kSpxgHFH6zzCg/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/barricudas-denver-3?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 193,
+      "categories": [
+        {
+          "alias": "bars",
+          "title": "Bars"
+        },
+        {
+          "alias": "newamerican",
+          "title": "American (New)"
+        },
+        {
+          "alias": "karaoke",
+          "title": "Karaoke"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.7333,
+        "longitude": -104.975
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$$",
+      "location": {
+        "address1": "1076 Ogden St",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1076 Ogden St",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+13038608353",
+      "display_phone": "(303) 860-8353",
+      "distance": 471.85400976895755
+    },
+    {
+      "id": "No2VmMM6QchZSYtCk6k0vQ",
+      "alias": "dp-dough-denver",
+      "name": "DP Dough",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/n_Jf6frTGSxaS04rokx3_g/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/dp-dough-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 262,
+      "categories": [
+        {
+          "alias": "pizza",
+          "title": "Pizza"
+        },
+        {
+          "alias": "italian",
+          "title": "Italian"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.73971,
+        "longitude": -104.97111
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$",
+      "location": {
+        "address1": "1228 E Colfax Ave",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1228 E Colfax Ave",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+13038399663",
+      "display_phone": "(303) 839-9663",
+      "distance": 473.8230907508149
+    },
+    {
+      "id": "T0oDpWqZWOjli02HuIO3DQ",
+      "alias": "potager-denver",
+      "name": "Potager",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/VlzD2fAzWRhgCzjv-G3svQ/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/potager-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 306,
+      "categories": [
+        {
+          "alias": "newamerican",
+          "title": "American (New)"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.73396,
+        "longitude": -104.97542
+      },
+      "transactions": [],
+      "price": "$$$",
+      "location": {
+        "address1": "1109 Ogden St",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1109 Ogden St",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+13038325788",
+      "display_phone": "(303) 832-5788",
+      "distance": 474.7896964406433
+    },
+    {
+      "id": "aghAlq5-6EqLZsD75fiG3w",
+      "alias": "izu-denver",
+      "name": "Izu",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/Neu9Xt_B9Xtzoua81u_F6A/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/izu-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 249,
+      "categories": [
+        {
+          "alias": "japanese",
+          "title": "Japanese"
+        },
+        {
+          "alias": "salad",
+          "title": "Salad"
+        },
+        {
+          "alias": "sushi",
+          "title": "Sushi Bars"
+        }
+      ],
+      "rating": 4.5,
+      "coordinates": {
+        "latitude": 39.73973,
+        "longitude": -104.96889
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$$",
+      "location": {
+        "address1": "1528 E Colfax Ave",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1528 E Colfax Ave",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+13032847981",
+      "display_phone": "(303) 284-7981",
+      "distance": 482.8633017307323
+    },
+    {
+      "id": "R3kOhjqh7PTm9grePAjV9Q",
+      "alias": "denver-fresh-mex-denver",
+      "name": "Denver Fresh Mex",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/k6gHStpVK_VNv8nW7UmfYw/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/denver-fresh-mex-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 41,
+      "categories": [
+        {
+          "alias": "mexican",
+          "title": "Mexican"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.739751,
+        "longitude": -104.968226
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$",
+      "location": {
+        "address1": "1600 E Colfax Ave",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1600 E Colfax Ave",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+17204209955",
+      "display_phone": "(720) 420-9955",
+      "distance": 500.7109784474234
+    },
+    {
+      "id": "YwspX50B_dI7Ae66Uw_l6A",
+      "alias": "3-guys-pies-denver",
+      "name": "3 Guys Pies",
+      "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/4DP9-uQYr5iZeiXiJ4RUsA/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/3-guys-pies-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 193,
+      "categories": [
+        {
+          "alias": "pizza",
+          "title": "Pizza"
+        },
+        {
+          "alias": "salad",
+          "title": "Salad"
+        },
+        {
+          "alias": "chicken_wings",
+          "title": "Chicken Wings"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.74018,
+        "longitude": -104.9695
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$$",
+      "location": {
+        "address1": "1501 E Colfax Ave",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1501 E Colfax Ave",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+13036234897",
+      "display_phone": "(303) 623-4897",
+      "distance": 529.3556099084666
+    },
+    {
+      "id": "sztJlQL-Nora18xpsnauLg",
+      "alias": "burger-king-denver-11",
+      "name": "Burger King",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/y18CTfoYo5BpCvjc2uwRvw/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/burger-king-denver-11?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 29,
+      "categories": [
+        {
+          "alias": "hotdogs",
+          "title": "Fast Food"
+        },
+        {
+          "alias": "burgers",
+          "title": "Burgers"
+        }
+      ],
+      "rating": 1.5,
+      "coordinates": {
+        "latitude": 39.7396965026855,
+        "longitude": -104.967559814453
+      },
+      "transactions": [
+        "delivery"
+      ],
+      "price": "$",
+      "location": {
+        "address1": "1680 E Colfax Ave",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1680 E Colfax Ave",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+13033221773",
+      "display_phone": "(303) 322-1773",
+      "distance": 529.9321631384229
+    },
+    {
+      "id": "BwsrH7vf9Ir_-dvxUboVVA",
+      "alias": "spices-cafe-denver",
+      "name": "Spices Cafe",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/N78ivTATTX_EuS3VRkJcDQ/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/spices-cafe-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 307,
+      "categories": [
+        {
+          "alias": "tradamerican",
+          "title": "American (Traditional)"
+        },
+        {
+          "alias": "breakfast_brunch",
+          "title": "Breakfast & Brunch"
+        },
+        {
+          "alias": "salad",
+          "title": "Salad"
+        }
+      ],
+      "rating": 4.5,
+      "coordinates": {
+        "latitude": 39.740304,
+        "longitude": -104.969427
+      },
+      "transactions": [],
+      "price": "$",
+      "location": {
+        "address1": "1510 Humboldt St",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1510 Humboldt St",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+13035201708",
+      "display_phone": "(303) 520-1708",
+      "distance": 536.0741816746827
+    },
+    {
+      "id": "MWFGHr6NOg7pAoLgbgFdsQ",
+      "alias": "doppio-coffee-denver",
+      "name": "Doppio Coffee",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/2IppW9yj8KcuVozMePqxPw/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/doppio-coffee-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 27,
+      "categories": [
+        {
+          "alias": "coffee",
+          "title": "Coffee & Tea"
+        },
+        {
+          "alias": "breakfast_brunch",
+          "title": "Breakfast & Brunch"
+        },
+        {
+          "alias": "sandwiches",
+          "title": "Sandwiches"
+        }
+      ],
+      "rating": 5,
+      "coordinates": {
+        "latitude": 39.7402,
+        "longitude": -104.97129
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "location": {
+        "address1": "1245 E Colfax Ave",
+        "address2": "Ste 105",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1245 E Colfax Ave",
+          "Ste 105",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+13035377794",
+      "display_phone": "(303) 537-7794",
+      "distance": 539.8171882096158
+    },
+    {
+      "id": "ALeBQxSLsm0He_FYdmA6UA",
+      "alias": "rocky-fin-poke-bar-denver",
+      "name": "Rocky Fin Poke Bar",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/-6m2XipgC6CJg0HH7mjlbQ/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/rocky-fin-poke-bar-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 209,
+      "categories": [
+        {
+          "alias": "poke",
+          "title": "Poke"
+        },
+        {
+          "alias": "hawaiian",
+          "title": "Hawaiian"
+        }
+      ],
+      "rating": 5,
+      "coordinates": {
+        "latitude": 39.7402,
+        "longitude": -104.97129
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$",
+      "location": {
+        "address1": "1245 E Colfax Ave",
+        "address2": "Ste 103",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1245 E Colfax Ave",
+          "Ste 103",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+13038611188",
+      "display_phone": "(303) 861-1188",
+      "distance": 539.8171882096158
+    },
+    {
+      "id": "FfwLdr5-TBINeZbR4ey_WQ",
+      "alias": "irish-snug-denver",
+      "name": "Irish Snug",
+      "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/w7imN29iPqvcFUo6ZTdQAw/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/irish-snug-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 449,
+      "categories": [
+        {
+          "alias": "irish",
+          "title": "Irish"
+        },
+        {
+          "alias": "pubs",
+          "title": "Pubs"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.7402,
+        "longitude": -104.97194
+      },
+      "transactions": [],
+      "price": "$$",
+      "location": {
+        "address1": "1201 E Colfax Ave",
+        "address2": null,
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1201 E Colfax Ave",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+13038391394",
+      "display_phone": "(303) 839-1394",
+      "distance": 541.9058239564879
+    },
+    {
+      "id": "3TWWt2PrMmU6A5IAhpFONw",
+      "alias": "the-corner-beet-denver",
+      "name": "The Corner Beet",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/mImDiWrsWb6JxW63D_fdkA/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/the-corner-beet-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 194,
+      "categories": [
+        {
+          "alias": "juicebars",
+          "title": "Juice Bars & Smoothies"
+        },
+        {
+          "alias": "vegetarian",
+          "title": "Vegetarian"
+        },
+        {
+          "alias": "vegan",
+          "title": "Vegan"
+        }
+      ],
+      "rating": 4.5,
+      "coordinates": {
+        "latitude": 39.7385320737529,
+        "longitude": -104.975359462606
+      },
+      "transactions": [
+        "delivery"
+      ],
+      "price": "$$",
+      "location": {
+        "address1": "1401 Ogden St",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1401 Ogden St",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+17202954447",
+      "display_phone": "(720) 295-4447",
+      "distance": 550.5340597527891
+    },
+    {
+      "id": "SogywYfZ2MSELE5YuLAUdw",
+      "alias": "triple-tree-cafe-denver",
+      "name": "Triple Tree Cafe",
+      "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/yhyJ0vZShzSJkahNr1Im_g/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/triple-tree-cafe-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 42,
+      "categories": [
+        {
+          "alias": "breakfast_brunch",
+          "title": "Breakfast & Brunch"
+        },
+        {
+          "alias": "coffee",
+          "title": "Coffee & Tea"
+        },
+        {
+          "alias": "sandwiches",
+          "title": "Sandwiches"
+        }
+      ],
+      "rating": 4.5,
+      "coordinates": {
+        "latitude": 39.7403812777677,
+        "longitude": -104.971633069217
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$$",
+      "location": {
+        "address1": "1201 E Colfax Ave",
+        "address2": "Ste 102",
+        "address3": null,
+        "city": "Denver",
+        "zip_code": "80218",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1201 E Colfax Ave",
+          "Ste 102",
+          "Denver, CO 80218"
+        ]
+      },
+      "phone": "+17209171000",
+      "display_phone": "(720) 917-1000",
+      "distance": 552.9615844114008
+    }
+  ],
+  "total": 198,
+  "region": {
+    "center": {
+      "longitude": -104.97024536132812,
+      "latitude": 39.73552421220229
+    }
+  }
+}

--- a/spec/fixtures/business_search_specific.json
+++ b/spec/fixtures/business_search_specific.json
@@ -1,0 +1,874 @@
+{
+  "businesses": [
+    {
+      "id": "AufxrKk-COzfAMr9KMVWRA",
+      "alias": "mortons-the-steakhouse-denver-2",
+      "name": "Morton's The Steakhouse",
+      "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/c86oV0nZkTOm2Pt9tKFYog/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/mortons-the-steakhouse-denver-2?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 168,
+      "categories": [
+        {
+          "alias": "steak",
+          "title": "Steakhouses"
+        },
+        {
+          "alias": "tradamerican",
+          "title": "American (Traditional)"
+        },
+        {
+          "alias": "bars",
+          "title": "Bars"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.7530570684622,
+        "longitude": -104.998126650297
+      },
+      "transactions": [],
+      "price": "$$$$",
+      "location": {
+        "address1": "1745 Wazee St",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1745 Wazee St",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13038253353",
+      "display_phone": "(303) 825-3353",
+      "distance": 42.8951457669453
+    },
+    {
+      "id": "IFVAm31yNaKw5_Sa1TuP4g",
+      "alias": "rodizio-grill-denver-denver",
+      "name": "Rodizio Grill Denver",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/_fcMX4Gnhocq_Gd1QQANWA/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/rodizio-grill-denver-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 412,
+      "categories": [
+        {
+          "alias": "steak",
+          "title": "Steakhouses"
+        },
+        {
+          "alias": "brazilian",
+          "title": "Brazilian"
+        },
+        {
+          "alias": "buffets",
+          "title": "Buffets"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.7539989260745,
+        "longitude": -104.998431005314
+      },
+      "transactions": [],
+      "price": "$$$",
+      "location": {
+        "address1": "1801 Wynkoop St",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1801 Wynkoop St",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13032949277",
+      "display_phone": "(303) 294-9277",
+      "distance": 68.69695804223923
+    },
+    {
+      "id": "mzOAkvH-4WIfQuR3uCs87g",
+      "alias": "hopdoddy-burger-bar-denver",
+      "name": "Hopdoddy Burger Bar",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/CdADjEj_McY9D9Mpk6Jvgg/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/hopdoddy-burger-bar-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 756,
+      "categories": [
+        {
+          "alias": "burgers",
+          "title": "Burgers"
+        }
+      ],
+      "rating": 4.5,
+      "coordinates": {
+        "latitude": 39.7534294,
+        "longitude": -104.9991989
+      },
+      "transactions": [
+        "pickup"
+      ],
+      "price": "$$",
+      "location": {
+        "address1": "1747 Wynkoop St",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1747 Wynkoop St",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13034462337",
+      "display_phone": "(303) 446-2337",
+      "distance": 71.83002191403978
+    },
+    {
+      "id": "AGopPiE4IZUdmw7yo6PIow",
+      "alias": "machete-tequila-tacos-denver-2",
+      "name": "Machete Tequila + Tacos",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/itzCWO24X3YZnmZil8l_wg/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/machete-tequila-tacos-denver-2?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 400,
+      "categories": [
+        {
+          "alias": "mexican",
+          "title": "Mexican"
+        },
+        {
+          "alias": "bars",
+          "title": "Bars"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.7530920474473,
+        "longitude": -104.999181073136
+      },
+      "transactions": [
+        "restaurant_reservation"
+      ],
+      "price": "$$",
+      "location": {
+        "address1": "1730 Wynkoop St",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1730 Wynkoop St",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+17206127698",
+      "display_phone": "(720) 612-7698",
+      "distance": 74.29847951613952
+    },
+    {
+      "id": "xxIlb8836QDY8iPNldVmfA",
+      "alias": "venice-ristorante-denver",
+      "name": "Venice Ristorante",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/ED8m2RIhnMVY2b0nGPlIWQ/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/venice-ristorante-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 294,
+      "categories": [
+        {
+          "alias": "italian",
+          "title": "Italian"
+        },
+        {
+          "alias": "wine_bars",
+          "title": "Wine Bars"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.7527782,
+        "longitude": -104.999532
+      },
+      "transactions": [],
+      "price": "$$$",
+      "location": {
+        "address1": "1700 Wynkoop St",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1700 Wynkoop St",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13035342222",
+      "display_phone": "(303) 534-2222",
+      "distance": 107.5641883936665
+    },
+    {
+      "id": "M-juFFD0ALOPWtSb5xrblA",
+      "alias": "icehouse-tavern-denver",
+      "name": "Icehouse Tavern",
+      "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/0Yerrv1H5NBylhLA2vxojA/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/icehouse-tavern-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 126,
+      "categories": [
+        {
+          "alias": "bars",
+          "title": "Bars"
+        },
+        {
+          "alias": "newamerican",
+          "title": "American (New)"
+        }
+      ],
+      "rating": 3,
+      "coordinates": {
+        "latitude": 39.7543786493017,
+        "longitude": -104.998059878934
+      },
+      "transactions": [
+        "pickup"
+      ],
+      "price": "$$",
+      "location": {
+        "address1": "1801 Wynkoop St",
+        "address2": "Ste 150",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1801 Wynkoop St",
+          "Ste 150",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13032923775",
+      "display_phone": "(303) 292-3775",
+      "distance": 114.56409617571293
+    },
+    {
+      "id": "aJbK_xFPvIP46YkbvqaMRg",
+      "alias": "lou-s-hot-and-naked-denver",
+      "name": "Lou’s Hot and Naked",
+      "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/6PL5c8raZnACQjsILLPqoA/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/lou-s-hot-and-naked-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 4,
+      "categories": [
+        {
+          "alias": "tradamerican",
+          "title": "American (Traditional)"
+        },
+        {
+          "alias": "sandwiches",
+          "title": "Sandwiches"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.75337,
+        "longitude": -104.99703
+      },
+      "transactions": [],
+      "location": {
+        "address1": "1800 Wazee St",
+        "address2": "",
+        "address3": null,
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1800 Wazee St",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "",
+      "display_phone": "",
+      "distance": 116.93864614502326
+    },
+    {
+      "id": "ni3jbdlVOB6k-yds5ylsEg",
+      "alias": "mano-pastaria-denver",
+      "name": "Mano Pastaria",
+      "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/Imf9fLW2gTQCelL8pcosGQ/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/mano-pastaria-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 4,
+      "categories": [
+        {
+          "alias": "pastashops",
+          "title": "Pasta Shops"
+        },
+        {
+          "alias": "italian",
+          "title": "Italian"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.7531902407197,
+        "longitude": -104.997044150443
+      },
+      "transactions": [],
+      "location": {
+        "address1": "1800 Wazee St",
+        "address2": "Ste 100",
+        "address3": null,
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1800 Wazee St",
+          "Ste 100",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "",
+      "display_phone": "",
+      "distance": 117.66284444670109
+    },
+    {
+      "id": "KwmKhdWpcIzypdjAUNrc7w",
+      "alias": "mercantile-dining-and-provision-denver",
+      "name": "Mercantile Dining & Provision",
+      "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/La36RRv14CheGs4x5WAR2Q/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/mercantile-dining-and-provision-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 931,
+      "categories": [
+        {
+          "alias": "bars",
+          "title": "Bars"
+        },
+        {
+          "alias": "newamerican",
+          "title": "American (New)"
+        }
+      ],
+      "rating": 4.5,
+      "coordinates": {
+        "latitude": 39.7536149959513,
+        "longitude": -104.999776429002
+      },
+      "transactions": [],
+      "price": "$$",
+      "location": {
+        "address1": "1701 Wynkoop St",
+        "address2": "Ste 155",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1701 Wynkoop St",
+          "Ste 155",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+17204603733",
+      "display_phone": "(720) 460-3733",
+      "distance": 120.67495420208995
+    },
+    {
+      "id": "-TBaww1LQBzKfLJ8OSeymA",
+      "alias": "mangiamo-pronto-denver",
+      "name": "Mangiamo Pronto",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/r23-VxZwPYGuhmq9HtDcpA/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/mangiamo-pronto-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 165,
+      "categories": [
+        {
+          "alias": "italian",
+          "title": "Italian"
+        },
+        {
+          "alias": "pizza",
+          "title": "Pizza"
+        },
+        {
+          "alias": "bars",
+          "title": "Bars"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.7523487817565,
+        "longitude": -104.998833696898
+      },
+      "transactions": [],
+      "price": "$$",
+      "location": {
+        "address1": "1601 17th St",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1601 17th St",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13032971229",
+      "display_phone": "(303) 297-1229",
+      "distance": 120.74241972567829
+    },
+    {
+      "id": "hWdupym3JerJ2p_-wRj00A",
+      "alias": "snooze-an-a-m-eatery-denver-11",
+      "name": "Snooze, An A.M. Eatery",
+      "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/A3wqc0cQwqBf7Un1ckfkiQ/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/snooze-an-a-m-eatery-denver-11?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 807,
+      "categories": [
+        {
+          "alias": "breakfast_brunch",
+          "title": "Breakfast & Brunch"
+        },
+        {
+          "alias": "coffee",
+          "title": "Coffee & Tea"
+        },
+        {
+          "alias": "sandwiches",
+          "title": "Sandwiches"
+        }
+      ],
+      "rating": 4.5,
+      "coordinates": {
+        "latitude": 39.7534172798151,
+        "longitude": -104.999892472353
+      },
+      "transactions": [],
+      "price": "$$",
+      "location": {
+        "address1": "1701 Wynkoop St",
+        "address2": "Ste 150",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1701 Wynkoop St",
+          "Ste 150",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13038253536",
+      "display_phone": "(303) 825-3536",
+      "distance": 127.83415390516647
+    },
+    {
+      "id": "g1lbyi7U9SFheSp5eCRogA",
+      "alias": "huckleberry-roasters-at-dairy-block-denver",
+      "name": "Huckleberry Roasters at Dairy Block",
+      "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/5D4jaXjYMvjXgqBohSbtUA/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/huckleberry-roasters-at-dairy-block-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 29,
+      "categories": [
+        {
+          "alias": "coffeeroasteries",
+          "title": "Coffee Roasteries"
+        },
+        {
+          "alias": "breakfast_brunch",
+          "title": "Breakfast & Brunch"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.75337,
+        "longitude": -104.99703
+      },
+      "transactions": [],
+      "price": "$$",
+      "location": {
+        "address1": "1800 Wazee St",
+        "address2": "",
+        "address3": null,
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1800 Wazee St",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "",
+      "display_phone": "",
+      "distance": 134.00813641399216
+    },
+    {
+      "id": "AKwaSohpf9iaRXaUjV1IHQ",
+      "alias": "bonanno-brothers-denver",
+      "name": "Bonanno Brothers",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/cDzacJ7b9v-erMKYSew68g/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/bonanno-brothers-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 4,
+      "categories": [
+        {
+          "alias": "pizza",
+          "title": "Pizza"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.7533699,
+        "longitude": -104.99703
+      },
+      "transactions": [],
+      "location": {
+        "address1": "1800 Wazee St",
+        "address2": "",
+        "address3": null,
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1800 Wazee St",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "",
+      "display_phone": "",
+      "distance": 134.00813641399216
+    },
+    {
+      "id": "5lFq507HoSv4Kbw8xYLWiQ",
+      "alias": "maxlunch-denver-2",
+      "name": "Maxlunch",
+      "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/BdxlPLammPu8v8HUZqmTlQ/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/maxlunch-denver-2?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 6,
+      "categories": [
+        {
+          "alias": "sandwiches",
+          "title": "Sandwiches"
+        },
+        {
+          "alias": "hotdogs",
+          "title": "Fast Food"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.7542784363031,
+        "longitude": -104.997996836901
+      },
+      "transactions": [],
+      "price": "$$$$",
+      "location": {
+        "address1": "1899 Wynkoop St",
+        "address2": "Ste 125",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1899 Wynkoop St",
+          "Ste 125",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+17204571731",
+      "display_phone": "(720) 457-1731",
+      "distance": 134.52030524473201
+    },
+    {
+      "id": "lqNe_QMrAyZLnEr06F9S_w",
+      "alias": "jax-fish-house-lodo-denver",
+      "name": "Jax Fish House LoDo",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/hMx-pEFzspAQUDsFjzB2fg/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/jax-fish-house-lodo-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 729,
+      "categories": [
+        {
+          "alias": "seafood",
+          "title": "Seafood"
+        }
+      ],
+      "rating": 4.5,
+      "coordinates": {
+        "latitude": 39.7521259302617,
+        "longitude": -104.998515626984
+      },
+      "transactions": [],
+      "price": "$$",
+      "location": {
+        "address1": "1539 17th St",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1539 17th St",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13032925767",
+      "display_phone": "(303) 292-5767",
+      "distance": 139.99170277508148
+    },
+    {
+      "id": "Ko0xWJX2GIUq5NVoG-2-Uw",
+      "alias": "pigtrain-coffee-co-denver-2",
+      "name": "Pigtrain Coffee Co",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/_C5LiwcB_lHWpXYo8NmDKA/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/pigtrain-coffee-co-denver-2?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 192,
+      "categories": [
+        {
+          "alias": "cafes",
+          "title": "Cafes"
+        },
+        {
+          "alias": "desserts",
+          "title": "Desserts"
+        },
+        {
+          "alias": "coffee",
+          "title": "Coffee & Tea"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.7529491832963,
+        "longitude": -105.000133871164
+      },
+      "transactions": [],
+      "price": "$",
+      "location": {
+        "address1": "1701 Wynkoop St",
+        "address2": "",
+        "address3": "Union Station",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1701 Wynkoop St",
+          "Union Station",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+17204603708",
+      "display_phone": "(720) 460-3708",
+      "distance": 156.00593217594073
+    },
+    {
+      "id": "fdeVBWzB4jZV7QupbQSXUg",
+      "alias": "urban-farmer-denver-denver",
+      "name": "Urban Farmer Denver",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/WYSejWENjOPSn10RIttdkw/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/urban-farmer-denver-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 221,
+      "categories": [
+        {
+          "alias": "steak",
+          "title": "Steakhouses"
+        },
+        {
+          "alias": "tradamerican",
+          "title": "American (Traditional)"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.75208,
+        "longitude": -104.99929
+      },
+      "transactions": [],
+      "price": "$$$",
+      "location": {
+        "address1": "1659 Wazee St",
+        "address2": "",
+        "address3": null,
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1659 Wazee St",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13032626070",
+      "display_phone": "(303) 262-6070",
+      "distance": 159.91007219624987
+    },
+    {
+      "id": "y7v8I2jUO-JV66MlBNb3gQ",
+      "alias": "acme-delicatessen-denver-2",
+      "name": "Acme Delicatessen",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/fo9S_Ucih8XhP6GUuS7j1w/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/acme-delicatessen-denver-2?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 40,
+      "categories": [
+        {
+          "alias": "delis",
+          "title": "Delis"
+        }
+      ],
+      "rating": 2.5,
+      "coordinates": {
+        "latitude": 39.7530550976684,
+        "longitude": -105.000243522227
+      },
+      "transactions": [],
+      "price": "$$",
+      "location": {
+        "address1": "1701 Wynkoop St",
+        "address2": "",
+        "address3": "The Great Hall Of Denver Union Station",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1701 Wynkoop St",
+          "The Great Hall Of Denver Union Station",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+17204603706",
+      "display_phone": "(720) 460-3706",
+      "distance": 161.90747835960073
+    },
+    {
+      "id": "7J5A3Bkq5dAfAzvBxp1lnA",
+      "alias": "next-door-union-station-denver-4",
+      "name": "Next Door - Union Station",
+      "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/f-cs-VYBAJF_MLqcRXg0Wg/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/next-door-union-station-denver-4?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 281,
+      "categories": [
+        {
+          "alias": "bars",
+          "title": "Bars"
+        },
+        {
+          "alias": "tradamerican",
+          "title": "American (Traditional)"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.75305,
+        "longitude": -104.99995
+      },
+      "transactions": [],
+      "price": "$$",
+      "location": {
+        "address1": "1701 Wynkoop St",
+        "address2": "Ste 100",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1701 Wynkoop St",
+          "Ste 100",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+17204603730",
+      "display_phone": "(720) 460-3730",
+      "distance": 165.39805897280516
+    },
+    {
+      "id": "K_LyxTyTfafUytd75mMmMg",
+      "alias": "ultreia-denver",
+      "name": "Ultreia",
+      "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/tC3i5xYmEmkcmErD6pfEhQ/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/ultreia-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 120,
+      "categories": [
+        {
+          "alias": "tapas",
+          "title": "Tapas Bars"
+        },
+        {
+          "alias": "portuguese",
+          "title": "Portuguese"
+        },
+        {
+          "alias": "basque",
+          "title": "Basque"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.75305,
+        "longitude": -104.99995
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$$",
+      "location": {
+        "address1": "1701 Wynkoop St",
+        "address2": "Ste 125",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1701 Wynkoop St",
+          "Ste 125",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13035341970",
+      "display_phone": "(303) 534-1970",
+      "distance": 165.39805897280516
+    }
+  ],
+  "total": 492,
+  "region": {
+    "center": {
+      "longitude": -104.99839782714844,
+      "latitude": 39.75338164558922
+    }
+  }
+}

--- a/spec/fixtures/business_search_zip.json
+++ b/spec/fixtures/business_search_zip.json
@@ -1,0 +1,901 @@
+{
+  "businesses": [
+    {
+      "id": "idKs48V1lf8LQwvcFJjzGg",
+      "alias": "ali-baba-halal-denver",
+      "name": "Ali Baba Halal",
+      "image_url": "",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/ali-baba-halal-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 1,
+      "categories": [
+        {
+          "alias": "streetvendors",
+          "title": "Street Vendors"
+        },
+        {
+          "alias": "burgers",
+          "title": "Burgers"
+        },
+        {
+          "alias": "mideastern",
+          "title": "Middle Eastern"
+        }
+      ],
+      "rating": 3,
+      "coordinates": {
+        "latitude": 39.7430327,
+        "longitude": -104.9873792
+      },
+      "transactions": [],
+      "price": "$$",
+      "location": {
+        "address1": "Food Cart",
+        "address2": "",
+        "address3": "Civic Center Station - Colfax & Broadway",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "Food Cart",
+          "Civic Center Station - Colfax & Broadway",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "",
+      "display_phone": "",
+      "distance": 66.19568646807623
+    },
+    {
+      "id": "9EBwv92qSn1aFTZ-oK1wag",
+      "alias": "sandwich-board-denver-3",
+      "name": "Sandwich Board",
+      "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/C6rxwuCEQudhxZtVHq6-Xg/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/sandwich-board-denver-3?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 8,
+      "categories": [
+        {
+          "alias": "sandwiches",
+          "title": "Sandwiches"
+        }
+      ],
+      "rating": 3,
+      "coordinates": {
+        "latitude": 39.7440567016602,
+        "longitude": -104.986724853516
+      },
+      "transactions": [],
+      "price": "$",
+      "location": {
+        "address1": "1740 Broadway",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80274",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1740 Broadway",
+          "Denver, CO 80274"
+        ]
+      },
+      "phone": "+13038614280",
+      "display_phone": "(303) 861-4280",
+      "distance": 75.66534531678143
+    },
+    {
+      "id": "y9UfFDgf5MiypdgBSZi9Aw",
+      "alias": "poke303-denver-2",
+      "name": "Poke303",
+      "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/jeovrZ-9V7CSxVed26dwqw/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/poke303-denver-2?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 32,
+      "categories": [
+        {
+          "alias": "poke",
+          "title": "Poke"
+        },
+        {
+          "alias": "hawaiian",
+          "title": "Hawaiian"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.74291,
+        "longitude": -104.98576
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$$",
+      "location": {
+        "address1": "1660 Lincoln St",
+        "address2": "Ste 102",
+        "address3": null,
+        "city": "Denver",
+        "zip_code": "80264",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1660 Lincoln St",
+          "Ste 102",
+          "Denver, CO 80264"
+        ]
+      },
+      "phone": "+13038322998",
+      "display_phone": "(303) 832-2998",
+      "distance": 94.57839226168686
+    },
+    {
+      "id": "Bj9VTiTsEnTaXCEWKWCnaA",
+      "alias": "pizzeria-colore-denver",
+      "name": "Pizzeria Colore",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/uUJflW451AErzj3LbK9Y5w/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/pizzeria-colore-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 64,
+      "categories": [
+        {
+          "alias": "italian",
+          "title": "Italian"
+        },
+        {
+          "alias": "pizza",
+          "title": "Pizza"
+        }
+      ],
+      "rating": 4.5,
+      "coordinates": {
+        "latitude": 39.7432287,
+        "longitude": -104.9880444
+      },
+      "transactions": [
+        "pickup"
+      ],
+      "price": "$",
+      "location": {
+        "address1": "1647 Court Pl",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1647 Court Pl",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13035342111",
+      "display_phone": "(303) 534-2111",
+      "distance": 113.63588677957877
+    },
+    {
+      "id": "yBMsoP9G1d7pbX0dy5bLcw",
+      "alias": "superfruit-republic-denver-5",
+      "name": "Superfruit Republic",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/WkFuFvMyIW_xoAMrClCXsQ/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/superfruit-republic-denver-5?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 62,
+      "categories": [
+        {
+          "alias": "juicebars",
+          "title": "Juice Bars & Smoothies"
+        },
+        {
+          "alias": "acaibowls",
+          "title": "Acai Bowls"
+        },
+        {
+          "alias": "vegetarian",
+          "title": "Vegetarian"
+        }
+      ],
+      "rating": 4.5,
+      "coordinates": {
+        "latitude": 39.7442909242824,
+        "longitude": -104.987248298433
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$",
+      "location": {
+        "address1": "1776 N Broadway",
+        "address2": "Ste 115",
+        "address3": null,
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1776 N Broadway",
+          "Ste 115",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13039979407",
+      "display_phone": "(303) 997-9407",
+      "distance": 113.7042326412764
+    },
+    {
+      "id": "fg0ToLv23x3QRXmlx9WX7w",
+      "alias": "ship-tavern-denver-5",
+      "name": "Ship Tavern",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/3sn1hb09a-l6R1Oacj8icg/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/ship-tavern-denver-5?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 180,
+      "categories": [
+        {
+          "alias": "tradamerican",
+          "title": "American (Traditional)"
+        },
+        {
+          "alias": "desserts",
+          "title": "Desserts"
+        },
+        {
+          "alias": "bars",
+          "title": "Bars"
+        }
+      ],
+      "rating": 3,
+      "coordinates": {
+        "latitude": 39.74409,
+        "longitude": -104.98774
+      },
+      "transactions": [],
+      "price": "$$",
+      "location": {
+        "address1": "321 17th St",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "321 17th St",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13032973111",
+      "display_phone": "(303) 297-3111",
+      "distance": 118.01197643049171
+    },
+    {
+      "id": "7JJFmGrvqpWjzBMLPLXGjQ",
+      "alias": "ellyngtons-at-the-brown-palace-and-spa-denver-2",
+      "name": "Ellyngton's At The Brown Palace and Spa",
+      "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/i5iyWM9cin5D10FMnEql7w/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/ellyngtons-at-the-brown-palace-and-spa-denver-2?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 126,
+      "categories": [
+        {
+          "alias": "breakfast_brunch",
+          "title": "Breakfast & Brunch"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.74409,
+        "longitude": -104.98774
+      },
+      "transactions": [],
+      "price": "$$$",
+      "location": {
+        "address1": "321 17th St",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "321 17th St",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13032973111",
+      "display_phone": "(303) 297-3111",
+      "distance": 118.01197643049171
+    },
+    {
+      "id": "Sx8IdWF4s7AVp42B34uveA",
+      "alias": "palace-arms-denver-5",
+      "name": "Palace Arms",
+      "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/WtXzRVTEw3GlzI17xY3hoQ/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/palace-arms-denver-5?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 115,
+      "categories": [
+        {
+          "alias": "newamerican",
+          "title": "American (New)"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.7441132,
+        "longitude": -104.9878576
+      },
+      "transactions": [],
+      "price": "$$$$",
+      "location": {
+        "address1": "321 17th St",
+        "address2": "",
+        "address3": "The Brown Palace",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "321 17th St",
+          "The Brown Palace",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13032973111",
+      "display_phone": "(303) 297-3111",
+      "distance": 128.70369934469497
+    },
+    {
+      "id": "hIEau-Ze4rbjmoLWzefnoA",
+      "alias": "churchill-bar-denver-5",
+      "name": "Churchill Bar",
+      "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/I0XUV2XVky9y-p60YKfmDg/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/churchill-bar-denver-5?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 71,
+      "categories": [
+        {
+          "alias": "tradamerican",
+          "title": "American (Traditional)"
+        },
+        {
+          "alias": "sandwiches",
+          "title": "Sandwiches"
+        },
+        {
+          "alias": "cocktailbars",
+          "title": "Cocktail Bars"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.744219,
+        "longitude": -104.987822
+      },
+      "transactions": [],
+      "price": "$$",
+      "location": {
+        "address1": "321 17th St",
+        "address2": "",
+        "address3": "The Brown Palace",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "321 17th St",
+          "The Brown Palace",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13032973111",
+      "display_phone": "(303) 297-3111",
+      "distance": 134.59988020339603
+    },
+    {
+      "id": "jUmHnAmaZlExeL-hqWDVnA",
+      "alias": "the-delectable-egg-downtown-denver",
+      "name": "The Delectable Egg - Downtown",
+      "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/zZF39lJnf5GRCoj7pJVGdg/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/the-delectable-egg-downtown-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 334,
+      "categories": [
+        {
+          "alias": "breakfast_brunch",
+          "title": "Breakfast & Brunch"
+        },
+        {
+          "alias": "creperies",
+          "title": "Creperies"
+        },
+        {
+          "alias": "sandwiches",
+          "title": "Sandwiches"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.74312,
+        "longitude": -104.988405
+      },
+      "transactions": [
+        "pickup"
+      ],
+      "price": "$$",
+      "location": {
+        "address1": "1625 Court Pl",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1625 Court Pl",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13038925720",
+      "display_phone": "(303) 892-5720",
+      "distance": 145.92819141036014
+    },
+    {
+      "id": "aMqgBLM8zuJYUGQIhk3rlw",
+      "alias": "choice-market-denver-3",
+      "name": "Choice Market",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/1yvfj8wMvbvMhAhzm2utVA/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/choice-market-denver-3?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 36,
+      "categories": [
+        {
+          "alias": "convenience",
+          "title": "Convenience Stores"
+        },
+        {
+          "alias": "markets",
+          "title": "Fruits & Veggies"
+        },
+        {
+          "alias": "sandwiches",
+          "title": "Sandwiches"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.744548,
+        "longitude": -104.987053
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$$",
+      "location": {
+        "address1": "1770 N Broadway",
+        "address2": "",
+        "address3": null,
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1770 N Broadway",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+17204597233",
+      "display_phone": "(720) 459-7233",
+      "distance": 158.01354157473662
+    },
+    {
+      "id": "E-s08VJbxQPTs6BPquDY1g",
+      "alias": "potbelly-sandwich-shop-denver-2",
+      "name": "Potbelly Sandwich Shop",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/vPPSv8AgRPQvo5f3pZbYzw/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/potbelly-sandwich-shop-denver-2?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 51,
+      "categories": [
+        {
+          "alias": "sandwiches",
+          "title": "Sandwiches"
+        },
+        {
+          "alias": "hotdogs",
+          "title": "Fast Food"
+        },
+        {
+          "alias": "salad",
+          "title": "Salad"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.742998,
+        "longitude": -104.988756
+      },
+      "transactions": [
+        "delivery",
+        "pickup"
+      ],
+      "price": "$",
+      "location": {
+        "address1": "303 16th St",
+        "address2": "Ste 180",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "303 16th St",
+          "Ste 180",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13035869360",
+      "display_phone": "(303) 586-9360",
+      "distance": 178.04049844759174
+    },
+    {
+      "id": "WTe8uL6vF1ZuKAeJIvxR8w",
+      "alias": "la-loma-denver-2",
+      "name": "La Loma",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/Eva_5h8P-JR9i7RHltYw-g/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/la-loma-denver-2?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 1013,
+      "categories": [
+        {
+          "alias": "mexican",
+          "title": "Mexican"
+        },
+        {
+          "alias": "tex-mex",
+          "title": "Tex-Mex"
+        }
+      ],
+      "rating": 4,
+      "coordinates": {
+        "latitude": 39.744716,
+        "longitude": -104.987832
+      },
+      "transactions": [
+        "pickup"
+      ],
+      "price": "$$",
+      "location": {
+        "address1": "1801 Broadway",
+        "address2": "Unit 116",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1801 Broadway",
+          "Unit 116",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13034338300",
+      "display_phone": "(303) 433-8300",
+      "distance": 178.88926743539767
+    },
+    {
+      "id": "LpacOKG7MUFVtUlUq3TyZg",
+      "alias": "oasis-mexican-grill-denver",
+      "name": "Oasis Mexican Grill",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/IL2ltrXejx4ztNxZqT_quA/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/oasis-mexican-grill-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 15,
+      "categories": [
+        {
+          "alias": "mexican",
+          "title": "Mexican"
+        },
+        {
+          "alias": "foodstands",
+          "title": "Food Stands"
+        }
+      ],
+      "rating": 4.5,
+      "coordinates": {
+        "latitude": 39.7419803748459,
+        "longitude": -104.987898960109
+      },
+      "transactions": [],
+      "price": "$",
+      "location": {
+        "address1": "113 16th St",
+        "address2": "",
+        "address3": null,
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "113 16th St",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "",
+      "display_phone": "",
+      "distance": 182.48735685692762
+    },
+    {
+      "id": "rvwVnMWyWNTdu7mh6GRYzw",
+      "alias": "subway-denver-27",
+      "name": "Subway",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/n34PvK0nbYMUxlooc6DaLA/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/subway-denver-27?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 17,
+      "categories": [
+        {
+          "alias": "sandwiches",
+          "title": "Sandwiches"
+        },
+        {
+          "alias": "hotdogs",
+          "title": "Fast Food"
+        }
+      ],
+      "rating": 2.5,
+      "coordinates": {
+        "latitude": 39.74453,
+        "longitude": -104.985167
+      },
+      "transactions": [],
+      "price": "$",
+      "location": {
+        "address1": "1775 Sherman St",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80203",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1775 Sherman St",
+          "Denver, CO 80203"
+        ]
+      },
+      "phone": "+13038316262",
+      "display_phone": "(303) 831-6262",
+      "distance": 185.77034055114555
+    },
+    {
+      "id": "dtcTbF4S7ydNiMqGpcUC2A",
+      "alias": "noodles-and-company-denver-11",
+      "name": "Noodles & Company",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/EYnmlhijFPGPapzrC18CPQ/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/noodles-and-company-denver-11?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 76,
+      "categories": [
+        {
+          "alias": "noodles",
+          "title": "Noodles"
+        }
+      ],
+      "rating": 3,
+      "coordinates": {
+        "latitude": 39.7433,
+        "longitude": -104.98869
+      },
+      "transactions": [],
+      "price": "$",
+      "location": {
+        "address1": "303 16th St",
+        "address2": "Ste 150",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "303 16th St",
+          "Ste 150",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13036231700",
+      "display_phone": "(303) 623-1700",
+      "distance": 194.74875579287576
+    },
+    {
+      "id": "rKhTHJP13m-qw97J4D4vaA",
+      "alias": "bubu-republic-plaza-denver",
+      "name": "bubu Republic Plaza",
+      "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/FsPE0IQDj1hr5_PCk3Ofyw/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/bubu-republic-plaza-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 27,
+      "categories": [
+        {
+          "alias": "mexican",
+          "title": "Mexican"
+        },
+        {
+          "alias": "vegan",
+          "title": "Vegan"
+        },
+        {
+          "alias": "asianfusion",
+          "title": "Asian Fusion"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.7433,
+        "longitude": -104.98869
+      },
+      "transactions": [],
+      "price": "$$",
+      "location": {
+        "address1": "303 16th St",
+        "address2": "",
+        "address3": null,
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "303 16th St",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13035734919",
+      "display_phone": "(303) 573-4919",
+      "distance": 194.74875579287576
+    },
+    {
+      "id": "g9AHBMeoAeKQCo7wc9-ylQ",
+      "alias": "mcdonalds-denver-10",
+      "name": "McDonald's",
+      "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/kxGSyodljN_k2hUnS3k-1A/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/mcdonalds-denver-10?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 45,
+      "categories": [
+        {
+          "alias": "hotdogs",
+          "title": "Fast Food"
+        },
+        {
+          "alias": "burgers",
+          "title": "Burgers"
+        },
+        {
+          "alias": "coffee",
+          "title": "Coffee & Tea"
+        }
+      ],
+      "rating": 1.5,
+      "coordinates": {
+        "latitude": 39.741836,
+        "longitude": -104.988097
+      },
+      "transactions": [],
+      "price": "$",
+      "location": {
+        "address1": "200 16th St",
+        "address2": null,
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "200 16th St",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13035346567",
+      "display_phone": "(303) 534-6567",
+      "distance": 205.2771065215473
+    },
+    {
+      "id": "5QY2tWZc0sJhWbGrw4DgnQ",
+      "alias": "philadelphia-filly-denver",
+      "name": "Philadelphia Filly",
+      "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/r5MAUSw8KOjZE4yDA_M2MA/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/philadelphia-filly-denver?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 13,
+      "categories": [
+        {
+          "alias": "foodstands",
+          "title": "Food Stands"
+        },
+        {
+          "alias": "cheesesteaks",
+          "title": "Cheesesteaks"
+        },
+        {
+          "alias": "sandwiches",
+          "title": "Sandwiches"
+        }
+      ],
+      "rating": 4.5,
+      "coordinates": {
+        "latitude": 39.741460482669,
+        "longitude": -104.987492939178
+      },
+      "transactions": [],
+      "price": "$",
+      "location": {
+        "address1": "16TH St Mall At Broadway",
+        "address2": null,
+        "address3": null,
+        "city": "Denver",
+        "zip_code": "80238",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "16TH St Mall At Broadway",
+          "Denver, CO 80238"
+        ]
+      },
+      "phone": "+13037228722",
+      "display_phone": "(303) 722-8722",
+      "distance": 220.22391661823247
+    },
+    {
+      "id": "y7WwR_kx99ajbeztqDakXw",
+      "alias": "the-sandwich-board-denver-11",
+      "name": "The Sandwich Board",
+      "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/BAPCHN62SCSt1kaRwTMe6g/o.jpg",
+      "is_closed": false,
+      "url": "https://www.yelp.com/biz/the-sandwich-board-denver-11?adjust_creative=87PBg7bGZgP_uA1xaaYqzw&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=87PBg7bGZgP_uA1xaaYqzw",
+      "review_count": 13,
+      "categories": [
+        {
+          "alias": "delis",
+          "title": "Delis"
+        },
+        {
+          "alias": "sandwiches",
+          "title": "Sandwiches"
+        }
+      ],
+      "rating": 3.5,
+      "coordinates": {
+        "latitude": 39.7412223815918,
+        "longitude": -104.986717224121
+      },
+      "transactions": [],
+      "price": "$",
+      "location": {
+        "address1": "1560 Broadway",
+        "address2": "",
+        "address3": "",
+        "city": "Denver",
+        "zip_code": "80202",
+        "country": "US",
+        "state": "CO",
+        "display_address": [
+          "1560 Broadway",
+          "Denver, CO 80202"
+        ]
+      },
+      "phone": "+13039913331",
+      "display_phone": "(303) 991-3331",
+      "distance": 225.31915460291765
+    }
+  ],
+  "total": 503,
+  "region": {
+    "center": {
+      "longitude": -104.98672485351562,
+      "latitude": 39.74335089613333
+    }
+  }
+}


### PR DESCRIPTION
## Description of Changes
* Adds placeholder restaurant show page
* Adds different wishlist sections for default location and "other locations" (future feature will further group "other locations" by city/state)
* Hides "other locations" wishlists by default with js element to expand all (tests currently skipped because these are hidden with css/js, which capybara ignores)
* Adds form to matches for a specified location

closes # 6

## Type of change
- [x] New feature
- [ ] Bug Fix

# Check the correct boxes
- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

# Testing Changes
- [x] No Tests have been changed
- [ ] Some Tests have been changed

# Checklist:

- [ ] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code
