### PR TITLE
Fix map load

### DIFF
--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -31,9 +31,9 @@
       <div id="map"></div>
       <% provide :head_tags do %>
         <script>
-        document.addEventListener("DOMContentLoaded", function(){
-          initMap(<%=@main_address.latitude%>, <%=@main_address.longitude%>)
-        });
+          document.addEventListener("turbolinks:load", function(){
+            initMap(<%=@main_address.latitude%>, <%=@main_address.longitude%>)
+          });
         </script>
       <% end %>
     <% end %>

--- a/app/views/directions/show.html.erb
+++ b/app/views/directions/show.html.erb
@@ -3,25 +3,27 @@ Directions To <%= @restaurant.name %>
 <div id="directions_map"></div>
 
 <% provide :head_tags do %>
+
 <script>
-var origin = new google.maps.LatLng(<%=@address.latitude%>, <%=@address.longitude%>);
-var destination = new google.maps.LatLng(<%=@restaurant.latitude%>, <%=@restaurant.longitude%>);
+  var origin = new google.maps.LatLng(<%=@address.latitude%>, <%=@address.longitude%>);
+  var destination = new google.maps.LatLng(<%=@restaurant.latitude%>, <%=@restaurant.longitude%>);
 
-function genMap () {
-  var directionsDisplay = new google.maps.DirectionsRenderer();
-  var directionsService = new google.maps.DirectionsService();
+  function genMap () {
+    var directionsDisplay = new google.maps.DirectionsRenderer();
+    var directionsService = new google.maps.DirectionsService();
 
-  var mapOptions = {
-    zoom: 12,
-    center: origin
-  };
-  var directions_map = new google.maps.Map(document.getElementById('directions_map'), mapOptions);
-  directionsDisplay.setMap(directions_map);
-  calculateRoute(origin, destination, directionsDisplay, directionsService);
-}
+    var mapOptions = {
+      zoom: 12,
+      center: origin
+    };
+    var directions_map = new google.maps.Map(document.getElementById('directions_map'), mapOptions);
+    directionsDisplay.setMap(directions_map);
+    calculateRoute(origin, destination, directionsDisplay, directionsService);
+  }
 
-window.addEventListener("load", function(){
-  genMap();
-});
+  document.addEventListener("turbolinks:load", function(){
+    genMap();
+  });
 </script>
+
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,8 +8,6 @@
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
     <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{ENV['google_maps_api_key']}" %>
-    <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?callback=genMap&key=#{ENV['google_maps_api_key']}" %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= yield(:head_tags) %>
   </head>
 


### PR DESCRIPTION
## Description of Changes

Added turbolinks to event listeners in order to load google maps without refresh.

closes #

## Type of change
- [ ] New feature
- [x] Bug Fix

# Check the correct boxes
- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

# Testing Changes
- [x] No Tests have been changed
- [ ] Some Tests have been changed

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code
